### PR TITLE
Show added books on /mybooks page

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -42,7 +42,7 @@ function App() {
           <MyShelves />
         </Route>
         <Route path="/mybooks">
-          <MyBooks />
+          <MyBooks library={library} />
         </Route>
       </Switch>
       <NavFooter />

--- a/client/src/components/Library.js
+++ b/client/src/components/Library.js
@@ -1,9 +1,9 @@
 import PropTypes from 'prop-types';
 import styled from 'styled-components/macro';
 
-export default function Library({ library }) {
+export default function Library({ library, isStatic }) {
   return (
-    <BooksWrapper>
+    <BooksWrapper isStatic={isStatic}>
       {library.map((book) => {
         return (
           <BookCard key={book.id}>
@@ -30,7 +30,7 @@ const BooksWrapper = styled.section`
   justify-content: space-between;
   padding-bottom: 7rem;
   margin: 1rem auto;
-  width: 90%;
+  width: ${(props) => (props.isStatic ? '338px' : '90%')};
 `;
 
 const BookCard = styled.article`

--- a/client/src/components/Library.js
+++ b/client/src/components/Library.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import styled from 'styled-components/macro';
 
 export default function Library({ library }) {
@@ -53,3 +54,7 @@ const BookCard = styled.article`
     text-align: center;
   }
 `;
+
+Library.propTypes = {
+  library: PropTypes.array,
+};

--- a/client/src/components/Library.js
+++ b/client/src/components/Library.js
@@ -26,7 +26,7 @@ const BooksWrapper = styled.section`
   display: flex;
   flex-wrap: wrap;
   gap: 1rem;
-  justify-content: space-around;
+  justify-content: space-between;
   padding-bottom: 7rem;
   margin: 1rem auto;
   width: 90%;

--- a/client/src/components/Library.js
+++ b/client/src/components/Library.js
@@ -13,9 +13,7 @@ export default function Library({ library, isStatic }) {
               width="102.4"
               height="159.2"
             />
-            <div>
-              <p>{book.volumeInfo.title}</p>
-            </div>
+            <p>{book.volumeInfo.title}</p>
           </BookCard>
         );
       })}
@@ -47,11 +45,12 @@ const BookCard = styled.article`
 
   div {
     height: 3.6rem;
-    overflow: hidden;
   }
 
   p {
     text-align: center;
+    height: 3.6rem;
+    overflow: hidden;
   }
 `;
 

--- a/client/src/components/Library.js
+++ b/client/src/components/Library.js
@@ -1,0 +1,55 @@
+import styled from 'styled-components/macro';
+
+export default function Library({ library }) {
+  return (
+    <BooksWrapper>
+      {library.map((book) => {
+        return (
+          <BookCard key={book.id}>
+            <img
+              src={book.volumeInfo.imageLinks.thumbnail}
+              alt="Book Cover"
+              width="102.4"
+              height="159.2"
+            />
+            <div>
+              <p>{book.volumeInfo.title}</p>
+            </div>
+          </BookCard>
+        );
+      })}
+    </BooksWrapper>
+  );
+}
+
+const BooksWrapper = styled.section`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  justify-content: space-around;
+  padding-bottom: 7rem;
+  margin: 1rem auto;
+  width: 90%;
+`;
+
+const BookCard = styled.article`
+  align-items: center;
+  background: var(--primary);
+  border-radius: var(--border-radius);
+  box-shadow: var(--box-shadow-offset-x) var(--box-shadow-offset-y)
+    var(--box-shadow-blur) var(--box-shadow-color);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 1rem;
+  width: 45%;
+
+  div {
+    height: 3.6rem;
+    overflow: hidden;
+  }
+
+  p {
+    text-align: center;
+  }
+`;

--- a/client/src/components/Library.js
+++ b/client/src/components/Library.js
@@ -6,7 +6,7 @@ export default function Library({ library, isStatic }) {
     <BooksWrapper isStatic={isStatic}>
       {library.map((book) => {
         return (
-          <BookCard key={book.id}>
+          <BookCard key={book.id} data-testid="library-book">
             <img
               src={book.volumeInfo.imageLinks.thumbnail}
               alt="Book Cover"

--- a/client/src/components/Library.md
+++ b/client/src/components/Library.md
@@ -1,0 +1,26 @@
+```jsx
+const library = [
+  {
+    volumeInfo: {
+      title: 'Die Furcht des Weisen / Band 1',
+      authors: ['Patrick Rothfuss'],
+      imageLinks: {
+        thumbnail:
+          'http://books.google.com/books/content?id=sjDmcnAKAysC&printsec=frontcover&img=1&zoom=1&edge=curl&source=gbs_api',
+      },
+    },
+  },
+  {
+    volumeInfo: {
+      title: 'Harry Potter und der Stein der Weisen',
+      authors: ['J.K. Rowling'],
+      imageLinks: {
+        thumbnail:
+          'http://books.google.com/books/content?id=XtekEncdTZcC&printsec=frontcover&img=1&zoom=1&edge=curl&source=gbs_api',
+      },
+    },
+  },
+];
+
+<Library library={library} isStatic />;
+```

--- a/client/src/pages/MyBooks.js
+++ b/client/src/pages/MyBooks.js
@@ -1,3 +1,10 @@
-export default function MyBooks() {
-  return <h2>My Books</h2>;
+import Library from '../components/Library';
+
+export default function MyBooks({ library }) {
+  return (
+    <>
+      <h2>My Books</h2>
+      <Library library={library} />
+    </>
+  );
 }

--- a/client/tests/e2e/library.spec.js
+++ b/client/tests/e2e/library.spec.js
@@ -1,0 +1,35 @@
+/* eslint-disable no-undef */
+
+/// <reference types='Cypress' />
+
+const testId = (id) => `[data-testid="${id}"]`;
+const SEARCH_BAR = testId('search-bar');
+const ADD_REMOVE_BUTTON = testId('add-and-remove-button');
+const LIBRARY_BOOK = testId('library-book');
+
+function clickAddButton() {
+  cy.visit('/home');
+  cy.get(SEARCH_BAR).type('Die Furcht des Weisen / Band 1');
+  cy.get(ADD_REMOVE_BUTTON).first().contains('Add').click();
+}
+
+function checkForBook() {
+  cy.get('[href="/mybooks"]').click();
+  cy.get(LIBRARY_BOOK).should('contain', 'Weisen');
+}
+
+describe('Display added Books', () => {
+  it('shows added books on /mybooks page', () => {
+    clickAddButton();
+    checkForBook();
+  });
+  it('removes book from /mybooks when clicking remove', () => {
+    clickAddButton();
+    checkForBook();
+    cy.get('[href="/home"]').click();
+    cy.get(SEARCH_BAR).type('Die Furcht des Weisen / Band 1');
+    cy.get(ADD_REMOVE_BUTTON).first().contains('Remove').click();
+    cy.get('[href="/mybooks"]').click();
+    cy.get(LIBRARY_BOOK).should('not.exist');
+  });
+});

--- a/client/tests/e2e/library.spec.js
+++ b/client/tests/e2e/library.spec.js
@@ -23,12 +23,15 @@ describe('Display added Books', () => {
     clickAddButton();
     checkForBook();
   });
+});
+
+describe('Remove Books Frim Library', () => {
   it('removes book from /mybooks when clicking remove', () => {
     clickAddButton();
     checkForBook();
     cy.get('[href="/home"]').click();
     cy.get(SEARCH_BAR).type('Die Furcht des Weisen / Band 1');
-    cy.get(ADD_REMOVE_BUTTON).first().contains('Remove').click();
+    cy.get(ADD_REMOVE_BUTTON).contains('Remove').click();
     cy.get('[href="/mybooks"]').click();
     cy.get(LIBRARY_BOOK).should('not.exist');
   });


### PR DESCRIPTION
Thanks for reviewing :)

This feature branch adds functionality to display added books (adding via search on /home) on the /mybooks page. Removing books on search, also removes books from the /mybooks page.

If you want to try this locally, starting the server via `npm run dev` from root should work if you remove the api key from the fetch function request in the backend (server/controller/search.controller.js):

`const searchAddress = 'https://www.googleapis.com/books/v1/volumes?key=${apiKey}&maxResults=25&q=';` -> `const searchAddress = 'https://www.googleapis.com/books/v1/volumes?maxResults=25&q=';`