### PR TITLE
Add Books to Shelf / Compartment

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -93,16 +93,20 @@ function App() {
   }
 
   function getBookLocation(book) {
-    const shelf = shelves.find(
-      (shelf) => shelf.id === book.shelfLocation.bookshelf
-    );
-    const column = shelf.columns.find(
-      (column) => column.id === book.shelfLocation.column
-    );
-    const compartment = column.compartments.find(
-      (compartment) => compartment.id === book.shelfLocation.compartment
-    );
-    return `${shelf.name}, Column ${column.column}, Compartment ${compartment.compartment}`;
+    if (book.shelfLocation) {
+      const shelf = shelves.find(
+        (shelf) => shelf.id === book.shelfLocation.bookshelf
+      );
+      const column = shelf.columns.find(
+        (column) => column.id === book.shelfLocation.column
+      );
+      const compartment = column.compartments.find(
+        (compartment) => compartment.id === book.shelfLocation.compartment
+      );
+      return `${shelf.name}, Column ${column.column}, Compartment ${compartment.compartment}`;
+    } else {
+      return `Not stored in a shelf.`;
+    }
   }
 
   function renderBookDetails(book) {

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -47,7 +47,7 @@ function App() {
       />
     );
   }
-
+  console.log(shelves);
   function renderBookDetailsHelper(book) {
     setDetailedBook(book);
     setView('details');
@@ -80,6 +80,7 @@ function App() {
           <Home
             onToggleToAndFromLibrary={toggleToAndFromLibrary}
             isInLibrary={isInLibrary}
+            shelves={shelves}
           />
         </Route>
         <Route exact path="/myshelves">

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -38,16 +38,6 @@ function App() {
     return library.find((book) => book.id === focusedBook.id);
   }
 
-  function renderBookDetails(book) {
-    return (
-      <BookDetails
-        book={book}
-        onRemoveDetailView={() => setView('')}
-        onAddRating={addRating}
-      />
-    );
-  }
-
   console.log(library);
   console.log(shelves);
 
@@ -104,6 +94,30 @@ function App() {
   function addRefToBookAndShelf(location, bookToUpdate) {
     updateBook('shelfLocation', location, bookToUpdate);
     updateBooksInCompartment('storedBooks', location, bookToUpdate);
+  }
+
+  function getBookLocation(book) {
+    const shelf = shelves.find(
+      (shelf) => shelf.id === book.shelfLocation.bookshelf
+    );
+    const column = shelf.columns.find(
+      (column) => column.id === book.shelfLocation.column
+    );
+    const compartment = column.compartments.find(
+      (compartment) => compartment.id === book.shelfLocation.compartment
+    );
+    return `${shelf.name}, Column ${column.column}, Compartment ${compartment.compartment}`;
+  }
+
+  function renderBookDetails(book) {
+    return (
+      <BookDetails
+        book={book}
+        onRemoveDetailView={() => setView('')}
+        onAddRating={addRating}
+        onGetBookLocation={getBookLocation}
+      />
+    );
   }
 
   return (

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -48,19 +48,49 @@ function App() {
     );
   }
 
+  console.log(library);
+  console.log(shelves);
+
   function renderBookDetailsHelper(book) {
     setDetailedBook(book);
     setView('details');
   }
 
   function updateBook(property, value, bookToUpdate) {
-    const upDatedBooks = library.map((book) => {
+    const updatedBooks = library.map((book) => {
       if (book.id === bookToUpdate.id) {
         book[property] = value;
       }
       return book;
     });
-    setLibrary(upDatedBooks);
+    setLibrary(updatedBooks);
+  }
+
+  function updateBooksInCompartment(property, selection, book) {
+    const updatedShelves = shelves.map((shelf) => {
+      if (shelf.id === selection.bookshelf) {
+        console.log(shelf);
+        shelf.columns.map((column) => {
+          if (column.id === selection.column) {
+            column.compartments.map((compartment) => {
+              if (compartment.id === selection.compartment) {
+                let existingBooks;
+                compartment[property]
+                  ? (existingBooks = [compartment[property]])
+                  : (existingBooks = '');
+                existingBooks === ''
+                  ? (compartment[property] = book.id)
+                  : (compartment[property] = [...existingBooks, book.id]);
+              }
+              return compartment;
+            });
+          }
+          return column;
+        });
+      }
+      return shelf;
+    });
+    setShelves(updatedShelves);
   }
 
   function addRating(rating, bookToUpdate) {
@@ -69,6 +99,11 @@ function App() {
 
   function addShelf(shelf) {
     setShelves([...shelves, shelf]);
+  }
+
+  function addRefToBookAndShelf(location, bookToUpdate) {
+    updateBook('shelfLocation', location, bookToUpdate);
+    updateBooksInCompartment('storedBooks', location, bookToUpdate);
   }
 
   return (
@@ -81,6 +116,7 @@ function App() {
             onToggleToAndFromLibrary={toggleToAndFromLibrary}
             isInLibrary={isInLibrary}
             shelves={shelves}
+            onSelectShelf={addRefToBookAndShelf}
           />
         </Route>
         <Route exact path="/myshelves">

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -55,16 +55,16 @@ function App() {
 
   function updateBooksInCompartment(property, selection, book) {
     const updatedShelves = shelves.map((shelf) => {
-      if (shelf.id === selection.bookshelf) {
+      if (shelf.id === selection.bookshelfId) {
         shelf.columns.map((column) => {
-          if (column.id === selection.column) {
+          if (column.id === selection.columnId) {
             column.compartments.map((compartment) => {
-              if (compartment.id === selection.compartment) {
+              if (compartment.id === selection.compartmentId) {
                 let existingBooks;
                 compartment[property]
                   ? (existingBooks = compartment[property])
-                  : (existingBooks = '');
-                existingBooks === ''
+                  : (existingBooks = []);
+                existingBooks.length === 0
                   ? (compartment[property] = [book.id])
                   : (compartment[property] = [...existingBooks, book.id]);
               }
@@ -78,6 +78,7 @@ function App() {
     });
     setShelves(updatedShelves);
   }
+  console.log(shelves);
 
   function addRating(rating, bookToUpdate) {
     updateBook('rating', rating, bookToUpdate);

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -38,9 +38,6 @@ function App() {
     return library.find((book) => book.id === focusedBook.id);
   }
 
-  console.log(library);
-  console.log(shelves);
-
   function renderBookDetailsHelper(book) {
     setDetailedBook(book);
     setView('details');
@@ -59,17 +56,16 @@ function App() {
   function updateBooksInCompartment(property, selection, book) {
     const updatedShelves = shelves.map((shelf) => {
       if (shelf.id === selection.bookshelf) {
-        console.log(shelf);
         shelf.columns.map((column) => {
           if (column.id === selection.column) {
             column.compartments.map((compartment) => {
               if (compartment.id === selection.compartment) {
                 let existingBooks;
                 compartment[property]
-                  ? (existingBooks = [compartment[property]])
+                  ? (existingBooks = compartment[property])
                   : (existingBooks = '');
                 existingBooks === ''
-                  ? (compartment[property] = book.id)
+                  ? (compartment[property] = [book.id])
                   : (compartment[property] = [...existingBooks, book.id]);
               }
               return compartment;

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -47,7 +47,7 @@ function App() {
       />
     );
   }
-  console.log(shelves);
+
   function renderBookDetailsHelper(book) {
     setDetailedBook(book);
     setView('details');

--- a/client/src/components/AddAndRemoveButton.js
+++ b/client/src/components/AddAndRemoveButton.js
@@ -5,11 +5,14 @@ export default function AddAndRemoveButton({
   onToggleToAndFromLibrary,
   isInLibrary,
   onSetIsSelector,
+  onProvideBook,
 }) {
   function handleClick() {
     onToggleToAndFromLibrary();
     isInLibrary ? onSetIsSelector(() => false) : onSetIsSelector(() => true);
+    onProvideBook();
   }
+
   return (
     <ToggleButton
       data-testid="add-and-remove-button"

--- a/client/src/components/AddAndRemoveButton.js
+++ b/client/src/components/AddAndRemoveButton.js
@@ -9,7 +9,7 @@ export default function AddAndRemoveButton({
 }) {
   function handleClick() {
     onToggleToAndFromLibrary();
-    isInLibrary ? onSetIsSelector(() => false) : onSetIsSelector(() => true);
+    isInLibrary ? onSetIsSelector(false) : onSetIsSelector(true);
     onProvideBook();
   }
 

--- a/client/src/components/AddAndRemoveButton.js
+++ b/client/src/components/AddAndRemoveButton.js
@@ -4,11 +4,16 @@ import styled from 'styled-components';
 export default function AddAndRemoveButton({
   onToggleToAndFromLibrary,
   isInLibrary,
+  onSetIsSelector,
 }) {
+  function handleClick() {
+    onToggleToAndFromLibrary();
+    isInLibrary ? onSetIsSelector(() => false) : onSetIsSelector(() => true);
+  }
   return (
     <ToggleButton
       data-testid="add-and-remove-button"
-      onClick={onToggleToAndFromLibrary}
+      onClick={handleClick}
       isInLibrary={isInLibrary}
     >
       {isInLibrary ? 'Remove' : 'Add'}

--- a/client/src/components/BookDetails.js
+++ b/client/src/components/BookDetails.js
@@ -10,6 +10,7 @@ export default function BookDetails({
   isStatic,
   onRemoveDetailView,
   onAddRating,
+  onGetBookLocation,
 }) {
   return (
     <DetailsCard isStatic={isStatic} data-test-id="book-details">
@@ -52,7 +53,7 @@ export default function BookDetails({
         <LocationWrapper>
           <p>Location:</p>
           <div>
-            <p>Location will be added later</p>
+            <p>{onGetBookLocation(book)}</p>
           </div>
         </LocationWrapper>
         <LentWrapper>

--- a/client/src/components/BookDetails.md
+++ b/client/src/components/BookDetails.md
@@ -14,5 +14,10 @@ const book = {
   },
 };
 
-<BookDetails book={book} isStatic onAddRating={() => true} />;
+<BookDetails
+  book={book}
+  isStatic
+  onAddRating={() => true}
+  onGetBookLocation={() => true}
+/>;
 ```

--- a/client/src/components/GlobalSearch.js
+++ b/client/src/components/GlobalSearch.js
@@ -9,6 +9,7 @@ export default function GlobalSearch({
   onToggleToAndFromLibrary,
   isInLibrary,
   shelves,
+  onSelectShelf,
 }) {
   const [searchQuery, setSearchQuery] = useState('');
   const [searchedBooks, setSearchedBooks] = useState([]);
@@ -54,6 +55,7 @@ export default function GlobalSearch({
         onToggleToAndFromLibrary={onToggleToAndFromLibrary}
         isInLibrary={isInLibrary}
         shelves={shelves}
+        onSelectShelf={onSelectShelf}
       />
     </>
   );

--- a/client/src/components/GlobalSearch.js
+++ b/client/src/components/GlobalSearch.js
@@ -8,6 +8,7 @@ import SearchResult from './SearchResult';
 export default function GlobalSearch({
   onToggleToAndFromLibrary,
   isInLibrary,
+  shelves,
 }) {
   const [searchQuery, setSearchQuery] = useState('');
   const [searchedBooks, setSearchedBooks] = useState([]);
@@ -52,6 +53,7 @@ export default function GlobalSearch({
         searchedBooks={searchedBooks}
         onToggleToAndFromLibrary={onToggleToAndFromLibrary}
         isInLibrary={isInLibrary}
+        shelves={shelves}
       />
     </>
   );

--- a/client/src/components/SearchResult.js
+++ b/client/src/components/SearchResult.js
@@ -118,4 +118,6 @@ SearchResult.propTypes = {
   searchedBooks: PropTypes.array,
   onToggleToAndFromLibrary: PropTypes.func,
   isInLibrary: PropTypes.func,
+  shelves: PropTypes.array,
+  onSelectShelf: PropTypes.func,
 };

--- a/client/src/components/SearchResult.js
+++ b/client/src/components/SearchResult.js
@@ -11,6 +11,7 @@ export default function SearchResult({
   onToggleToAndFromLibrary,
   isInLibrary,
   shelves,
+  onSelectShelf,
 }) {
   const [isSelector, setIsSelector] = useState(false);
   const [selectedBook, setSelectedBook] = useState({});
@@ -25,7 +26,14 @@ export default function SearchResult({
 
   return (
     <>
-      {isSelector && <ShelfSelector shelves={shelves} book={selectedBook} />}
+      {isSelector && (
+        <ShelfSelector
+          shelves={shelves}
+          book={selectedBook}
+          onSetIsSelector={updateSelector}
+          onSelectShelf={onSelectShelf}
+        />
+      )}
       <SearchResultSection isStatic={isStatic}>
         {searchedBooks.map((book, index) => (
           <SearchResultCard

--- a/client/src/components/SearchResult.js
+++ b/client/src/components/SearchResult.js
@@ -1,16 +1,26 @@
 import PropTypes from 'prop-types';
 import styled from 'styled-components/macro';
+import { useState } from 'react';
 
 import AddAndRemoveButton from './AddAndRemoveButton';
+import ShelfSelector from './ShelfSelector';
 
 export default function SearchResult({
   searchedBooks,
   isStatic,
   onToggleToAndFromLibrary,
   isInLibrary,
+  shelves,
 }) {
+  const [isSelector, setIsSelector] = useState(false);
+
+  function updateSelector(bool) {
+    setIsSelector(bool);
+  }
+
   return (
     <SearchResultSection isStatic={isStatic}>
+      {isSelector && <ShelfSelector shelves={shelves} />}
       {searchedBooks.map((book, index) => (
         <SearchResultCard
           key={index}
@@ -33,6 +43,7 @@ export default function SearchResult({
           <AddAndRemoveButton
             onToggleToAndFromLibrary={() => onToggleToAndFromLibrary(book)}
             isInLibrary={isInLibrary(book)}
+            onSetIsSelector={updateSelector}
           />
         </SearchResultCard>
       ))}

--- a/client/src/components/SearchResult.js
+++ b/client/src/components/SearchResult.js
@@ -13,41 +13,49 @@ export default function SearchResult({
   shelves,
 }) {
   const [isSelector, setIsSelector] = useState(false);
+  const [selectedBook, setSelectedBook] = useState({});
 
   function updateSelector(bool) {
     setIsSelector(bool);
   }
 
-  return (
-    <SearchResultSection isStatic={isStatic}>
-      {isSelector && <ShelfSelector shelves={shelves} />}
-      {searchedBooks.map((book, index) => (
-        <SearchResultCard
-          key={index}
-          isStatic={isStatic}
-          data-testid="search-result"
-        >
-          <img
-            src={book.volumeInfo?.imageLinks?.thumbnail}
-            width="58"
-            height="90"
-            alt={book.volumeInfo.title || 'Book Cover'}
-          />
-          <BookInfo>
-            <BookTitle>
-              <p>{book.volumeInfo?.title}</p>
-            </BookTitle>
+  function provideBook(book) {
+    setSelectedBook(book);
+  }
 
-            <p>{book.volumeInfo?.authors?.[0]}</p>
-          </BookInfo>
-          <AddAndRemoveButton
-            onToggleToAndFromLibrary={() => onToggleToAndFromLibrary(book)}
-            isInLibrary={isInLibrary(book)}
-            onSetIsSelector={updateSelector}
-          />
-        </SearchResultCard>
-      ))}
-    </SearchResultSection>
+  return (
+    <>
+      {isSelector && <ShelfSelector shelves={shelves} book={selectedBook} />}
+      <SearchResultSection isStatic={isStatic}>
+        {searchedBooks.map((book, index) => (
+          <SearchResultCard
+            key={index}
+            isStatic={isStatic}
+            data-testid="search-result"
+          >
+            <img
+              src={book.volumeInfo?.imageLinks?.thumbnail}
+              width="58"
+              height="90"
+              alt={book.volumeInfo.title || 'Book Cover'}
+            />
+            <BookInfo>
+              <BookTitle>
+                <p>{book.volumeInfo?.title}</p>
+              </BookTitle>
+
+              <p>{book.volumeInfo?.authors?.[0]}</p>
+            </BookInfo>
+            <AddAndRemoveButton
+              onToggleToAndFromLibrary={() => onToggleToAndFromLibrary(book)}
+              isInLibrary={isInLibrary(book)}
+              onSetIsSelector={updateSelector}
+              onProvideBook={() => provideBook(book)}
+            />
+          </SearchResultCard>
+        ))}
+      </SearchResultSection>
+    </>
   );
 }
 

--- a/client/src/components/ShelfCreator.js
+++ b/client/src/components/ShelfCreator.js
@@ -44,7 +44,7 @@ export default function ShelfCreator({ onSaveShelf }) {
     if (event.target.id === 'compartments') {
       fieldValue = [];
       for (let i = 0; i < event.target.value; i++) {
-        fieldValue.push({ compartment: i + 1 });
+        fieldValue.push({ compartment: i + 1, id: uuidv4() });
       }
     }
     newShelf.columns[index] = {

--- a/client/src/components/ShelfCreator.js
+++ b/client/src/components/ShelfCreator.js
@@ -26,7 +26,7 @@ export default function ShelfCreator({ onSaveShelf }) {
         fieldValue.push({
           id: uuidv4(),
           column: i + 1,
-          compartments: [],
+          compartments: [{ compartment: 1, id: uuidv4() }],
           width: 1,
           height: 1,
         });

--- a/client/src/components/ShelfCreator.js
+++ b/client/src/components/ShelfCreator.js
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import styled from 'styled-components/macro';
 import { toast } from 'react-toastify';
+import { v4 as uuidv4 } from 'uuid';
 import { useState } from 'react';
 import Shelf from './Shelf';
 import SaveAddButton from './SaveAddButton';
@@ -8,6 +9,7 @@ import validateShelf from '../lib/validateShelf';
 
 export default function ShelfCreator({ onSaveShelf }) {
   const initialShelf = {
+    id: '',
     name: '',
     columns: [],
     color: '',
@@ -22,6 +24,7 @@ export default function ShelfCreator({ onSaveShelf }) {
       fieldValue = [];
       for (let i = 0; i < event.target.value; i++) {
         fieldValue.push({
+          id: uuidv4(),
           column: i + 1,
           compartments: [],
           width: 1,
@@ -30,7 +33,7 @@ export default function ShelfCreator({ onSaveShelf }) {
       }
     }
 
-    setShelf({ ...shelf, [fieldName]: fieldValue });
+    setShelf({ ...shelf, id: uuidv4(), [fieldName]: fieldValue });
     toast.dismiss();
   }
 

--- a/client/src/components/ShelfSelector.js
+++ b/client/src/components/ShelfSelector.js
@@ -25,7 +25,8 @@ export default function ShelfSelector({ shelves, book }) {
       compartment: '',
     });
   }
-  console.log(book);
+
+  console.log(selection);
   function handleColumnChange(event) {
     const columnIndex = shelves[shelfIndex].columns.findIndex(
       (column) => column.id === event.target.value
@@ -35,6 +36,7 @@ export default function ShelfSelector({ shelves, book }) {
   }
 
   function handleCompartmentChange(event) {
+    console.log(event.target.value);
     setSelection({ ...selection, compartment: event.target.value });
   }
 

--- a/client/src/components/ShelfSelector.js
+++ b/client/src/components/ShelfSelector.js
@@ -1,9 +1,10 @@
-import { useState } from 'react';
+import ProptTypes from 'prop-types';
 import styled from 'styled-components';
-
-import SaveAddButton from './SaveAddButton';
-import CloseIcon from '../images/closeIcon.svg';
 import { toast } from 'react-toastify';
+import { useState } from 'react';
+
+import CloseIcon from '../images/closeIcon.svg';
+import SaveAddButton from './SaveAddButton';
 import validateShelfSelection from '../lib/validateShelfSelection';
 
 export default function ShelfSelector({
@@ -191,8 +192,8 @@ const CloseButton = styled.img`
 
 const ShelfSelectorForm = styled.form`
   display: flex;
-  justify-content: space-around;
   flex-direction: column;
+  justify-content: space-around;
   margin: 1rem 0 1rem;
   width: 100%;
 
@@ -217,8 +218,8 @@ const ShelfPicker = styled.section`
 
 const BookInformation = styled.section`
   display: flex;
-  justify-content: space-between;
   gap: 1rem;
+  justify-content: space-between;
   width: 100%;
 `;
 
@@ -264,3 +265,10 @@ const BookSubTitle = styled.h5`
   max-height: 2rem;
   overflow: hidden;
 `;
+
+ShelfSelector.propTypes = {
+  shelves: PropTypes.array,
+  book: PropTypes.object,
+  onSetIsSelector: PropTypes.func,
+  onSelectShelf: PropTypes.func,
+};

--- a/client/src/components/ShelfSelector.js
+++ b/client/src/components/ShelfSelector.js
@@ -3,6 +3,8 @@ import styled from 'styled-components';
 
 import SaveAddButton from './SaveAddButton';
 import CloseIcon from '../images/closeIcon.svg';
+import { toast } from 'react-toastify';
+import validateShelfSelection from '../lib/validateShelfSelection';
 
 export default function ShelfSelector({
   shelves,
@@ -18,6 +20,7 @@ export default function ShelfSelector({
   const [selection, setSelection] = useState(initialSelection);
   const [shelfIndex, setShelfIndex] = useState(null);
   const [columnIndex, setColumnIndex] = useState(null);
+
   function handleBookShelfChange(event) {
     const shelfIndex = shelves.findIndex(
       (shelf) => shelf.id === event.target.value
@@ -29,26 +32,37 @@ export default function ShelfSelector({
       column: '',
       compartment: '',
     });
+    toast.dismiss('validationError');
   }
 
-  console.log(selection);
   function handleColumnChange(event) {
     const columnIndex = shelves[shelfIndex].columns.findIndex(
       (column) => column.id === event.target.value
     );
     columnIndex >= 0 ? setColumnIndex(columnIndex) : setColumnIndex(null);
     setSelection({ ...selection, column: event.target.value, compartment: '' });
+    toast.dismiss('validationError');
   }
 
   function handleCompartmentChange(event) {
-    console.log(event.target.value);
     setSelection({ ...selection, compartment: event.target.value });
+    toast.dismiss('validationError');
   }
 
   function handleSelectionSave(event) {
     event.preventDefault();
-    onSelectShelf(selection, book);
-    onSetIsSelector(false);
+    if (validateShelfSelection(selection)) {
+      onSelectShelf(selection, book);
+      onSetIsSelector(false);
+      toast.success('Book added to Shelf!', {
+        position: toast.POSITION.BOTTOM_CENTER,
+      });
+    } else {
+      toast.error('Please choose a shelf, column and compartment', {
+        position: toast.POSITION.BOTTOM_CENTER,
+        toastId: 'validationError',
+      });
+    }
   }
 
   return (

--- a/client/src/components/ShelfSelector.js
+++ b/client/src/components/ShelfSelector.js
@@ -4,7 +4,12 @@ import styled from 'styled-components';
 import SaveAddButton from './SaveAddButton';
 import CloseIcon from '../images/closeIcon.svg';
 
-export default function ShelfSelector({ shelves, book }) {
+export default function ShelfSelector({
+  shelves,
+  book,
+  onSetIsSelector,
+  onSelectShelf,
+}) {
   const initialSelection = {
     bookshelf: '',
     column: '',
@@ -40,9 +45,19 @@ export default function ShelfSelector({ shelves, book }) {
     setSelection({ ...selection, compartment: event.target.value });
   }
 
+  function handleSelectionSave(event) {
+    event.preventDefault();
+    onSelectShelf(selection, book);
+    onSetIsSelector(false);
+  }
+
   return (
     <ShelfSelectorCard>
-      <CloseButton src={CloseIcon} alt="Close Icon" />
+      <CloseButton
+        src={CloseIcon}
+        alt="Close Icon"
+        onClick={() => onSetIsSelector(false)}
+      />
       <BookInformation>
         <BookImageWrapper>
           <img
@@ -66,63 +81,65 @@ export default function ShelfSelector({ shelves, book }) {
           <p>ISBN: {book.volumeInfo?.industryIdentifiers[0]?.identifier}</p>
         </BookSpecs>
       </BookInformation>
-      <ShelfPicker>
-        <div>
-          <label htmlFor="bookshelf">Bookshelf</label>
-          <select
-            name="bookshelf"
-            id="bookshelf"
-            onChange={handleBookShelfChange}
-            value={selection.bookshelf}
-          >
-            <option value="">-Select-</option>
-            {shelves.length > 0 &&
-              shelves.map((shelf, index) => (
-                <option key={index} value={shelf.id}>
-                  {shelf.name}
-                </option>
-              ))}
-          </select>
-        </div>
-        <div>
-          <label htmlFor="column">Column</label>
-          <select
-            name="column"
-            id="column"
-            onChange={handleColumnChange}
-            value={selection.column}
-          >
-            <option value="">-Select-</option>
-            {shelfIndex !== null &&
-              shelves[shelfIndex].columns.map((column, index) => (
-                <option key={index} value={column.id}>
-                  {column.column}
-                </option>
-              ))}
-          </select>
-        </div>
-        <div>
-          <label htmlFor="compartment">Compartment</label>
-          <select
-            name="compartment"
-            id="compartment"
-            value={selection.compartment}
-            onChange={handleCompartmentChange}
-          >
-            <option value="">-Select-</option>
-            {shelfIndex !== null &&
-              columnIndex !== null &&
-              shelves[shelfIndex].columns[columnIndex].compartments.map(
-                (compartment, index) => (
-                  <option key={index} value={compartment.id}>
-                    {compartment.compartment}
+      <ShelfSelectorForm onSubmit={handleSelectionSave}>
+        <ShelfPicker>
+          <div>
+            <label htmlFor="bookshelf">Bookshelf</label>
+            <select
+              name="bookshelf"
+              id="bookshelf"
+              onChange={handleBookShelfChange}
+              value={selection.bookshelf}
+            >
+              <option value="">-Select-</option>
+              {shelves.length > 0 &&
+                shelves.map((shelf, index) => (
+                  <option key={index} value={shelf.id}>
+                    {shelf.name}
                   </option>
-                )
-              )}
-          </select>
-        </div>
-      </ShelfPicker>
-      <SaveAddButton text={'Save'} />
+                ))}
+            </select>
+          </div>
+          <div>
+            <label htmlFor="column">Column</label>
+            <select
+              name="column"
+              id="column"
+              onChange={handleColumnChange}
+              value={selection.column}
+            >
+              <option value="">-Select-</option>
+              {shelfIndex !== null &&
+                shelves[shelfIndex].columns.map((column, index) => (
+                  <option key={index} value={column.id}>
+                    {column.column}
+                  </option>
+                ))}
+            </select>
+          </div>
+          <div>
+            <label htmlFor="compartment">Compartment</label>
+            <select
+              name="compartment"
+              id="compartment"
+              value={selection.compartment}
+              onChange={handleCompartmentChange}
+            >
+              <option value="">-Select-</option>
+              {shelfIndex !== null &&
+                columnIndex !== null &&
+                shelves[shelfIndex].columns[columnIndex].compartments.map(
+                  (compartment, index) => (
+                    <option key={index} value={compartment.id}>
+                      {compartment.compartment}
+                    </option>
+                  )
+                )}
+            </select>
+          </div>
+        </ShelfPicker>
+        <SaveAddButton text={'Save'} />
+      </ShelfSelectorForm>
     </ShelfSelectorCard>
   );
 }
@@ -157,9 +174,11 @@ const CloseButton = styled.img`
   right: -10px;
   top: -10px;
 `;
-const ShelfPicker = styled.form`
+
+const ShelfSelectorForm = styled.form`
   display: flex;
   justify-content: space-around;
+  flex-direction: column;
   margin: 1rem 0 1rem;
   width: 100%;
 
@@ -175,6 +194,11 @@ const ShelfPicker = styled.form`
       var(--box-shadow-blur) var(--box-shadow-color);
     height: 2rem;
   }
+`;
+const ShelfPicker = styled.section`
+  display: flex;
+  justify-content: space-around;
+  margin-bottom: 1rem;
 `;
 
 const BookInformation = styled.section`

--- a/client/src/components/ShelfSelector.js
+++ b/client/src/components/ShelfSelector.js
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import styled from 'styled-components';
 
 import SaveAddButton from './SaveAddButton';
+import CloseIcon from '../images/closeIcon.svg';
 
 export default function ShelfSelector({ shelves, book }) {
   const initialSelection = {
@@ -12,15 +13,19 @@ export default function ShelfSelector({ shelves, book }) {
   const [selection, setSelection] = useState(initialSelection);
   const [shelfIndex, setShelfIndex] = useState(null);
   const [columnIndex, setColumnIndex] = useState(null);
-
   function handleBookShelfChange(event) {
     const shelfIndex = shelves.findIndex(
       (shelf) => shelf.id === event.target.value
     );
     shelfIndex >= 0 ? setShelfIndex(shelfIndex) : setShelfIndex(null);
-    setSelection({ ...selection, bookshelf: event.target.value, column: '' });
+    setSelection({
+      ...selection,
+      bookshelf: event.target.value,
+      column: '',
+      compartment: '',
+    });
   }
-
+  console.log(book);
   function handleColumnChange(event) {
     const columnIndex = shelves[shelfIndex].columns.findIndex(
       (column) => column.id === event.target.value
@@ -33,10 +38,32 @@ export default function ShelfSelector({ shelves, book }) {
     setSelection({ ...selection, compartment: event.target.value });
   }
 
-  console.log(columnIndex);
-  console.log(shelves);
   return (
     <ShelfSelectorCard>
+      <CloseButton src={CloseIcon} alt="Close Icon" />
+      <BookInformation>
+        <BookImageWrapper>
+          <img
+            src={
+              book.volumeInfo?.imageLinks?.thumbnail ||
+              book.volumeInfo?.imageLinks?.smallThumbnail
+            }
+            alt={book.volumeInfo?.title || 'Book Cover'}
+            width="128"
+            height="192"
+          />
+        </BookImageWrapper>
+
+        <BookSpecs>
+          <BookTitle>{book.volumeInfo?.title}</BookTitle>
+          {book.volumeInfo.subtitle && (
+            <BookSubTitle>{book.volumeInfo.subtitle}</BookSubTitle>
+          )}
+          <p>{book.volumeInfo?.authors?.[0]}</p>
+          <p>Released: {book.volumeInfo?.publishedDate?.substring(0, 4)}</p>
+          <p>ISBN: {book.volumeInfo?.industryIdentifiers[0]?.identifier}</p>
+        </BookSpecs>
+      </BookInformation>
       <ShelfPicker>
         <div>
           <label htmlFor="bookshelf">Bookshelf</label>
@@ -46,7 +73,7 @@ export default function ShelfSelector({ shelves, book }) {
             onChange={handleBookShelfChange}
             value={selection.bookshelf}
           >
-            <option value="">-Bookshelves-</option>
+            <option value="">-Select-</option>
             {shelves.length > 0 &&
               shelves.map((shelf, index) => (
                 <option key={index} value={shelf.id}>
@@ -63,7 +90,7 @@ export default function ShelfSelector({ shelves, book }) {
             onChange={handleColumnChange}
             value={selection.column}
           >
-            <option value="">-Column-</option>
+            <option value="">-Select-</option>
             {shelfIndex !== null &&
               shelves[shelfIndex].columns.map((column, index) => (
                 <option key={index} value={column.id}>
@@ -80,11 +107,12 @@ export default function ShelfSelector({ shelves, book }) {
             value={selection.compartment}
             onChange={handleCompartmentChange}
           >
-            <option value="">-Compartment-</option>
-            {columnIndex !== null &&
+            <option value="">-Select-</option>
+            {shelfIndex !== null &&
+              columnIndex !== null &&
               shelves[shelfIndex].columns[columnIndex].compartments.map(
                 (compartment, index) => (
-                  <option key={index} value={compartment.compartment}>
+                  <option key={index} value={compartment.id}>
                     {compartment.compartment}
                   </option>
                 )
@@ -97,19 +125,21 @@ export default function ShelfSelector({ shelves, book }) {
   );
 }
 const ShelfSelectorCard = styled.article`
+  align-items: center;
   background-color: var(--background);
   border-radius: var(--border-radius);
   box-shadow: 0 0 80px 80px rgba(0, 0, 0, 0.2);
   display: flex;
   flex-direction: column;
   flex-wrap: nowrap;
-  height: ${(props) => (props.isStatic ? '650px' : '20vh')};
+  height: ${(props) => (props.isStatic ? '650px' : '50vh')};
+  justify-content: center;
   margin: ${(props) => (props.isStatic ? '0 auto' : '50vh 50vw')};
   opacity: 0.95;
   padding: 1rem;
   position: ${(props) => (props.isStatic ? 'relative' : 'fixed')};
-  transform: ${(props) => (props.isStatic ? '' : 'translate(-50%, -180%)')};
-  width: ${(props) => (props.isStatic ? '338px' : '80vw')};
+  transform: ${(props) => (props.isStatic ? '' : 'translate(-50%, -100%)')};
+  width: ${(props) => (props.isStatic ? '338px' : '90vw')};
   z-index: 100;
 
   input,
@@ -120,10 +150,17 @@ const ShelfSelectorCard = styled.article`
   }
 `;
 
-const ShelfPicker = styled.section`
+const CloseButton = styled.img`
+  position: absolute;
+  right: -10px;
+  top: -10px;
+`;
+const ShelfPicker = styled.form`
   display: flex;
   justify-content: space-around;
-  margin: 1rem auto 2rem;
+  margin: 1rem 0 1rem;
+  width: 100%;
+
   label {
     display: block;
     font-size: 0.8rem;
@@ -136,4 +173,54 @@ const ShelfPicker = styled.section`
       var(--box-shadow-blur) var(--box-shadow-color);
     height: 2rem;
   }
+`;
+
+const BookInformation = styled.section`
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  width: 100%;
+`;
+
+const BookImageWrapper = styled.div`
+  align-items: flex-start;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  height: 100%;
+  justify-content: flex-start;
+  width: 40%;
+
+  img {
+    box-shadow: var(--box-shadow-offset-x) var(--box-shadow-offset-y)
+      var(--box-shadow-blur) var(--box-shadow-color);
+    width: 102px;
+    height: 154px;
+  }
+`;
+
+const BookSpecs = styled.div`
+  align-items: flex-start;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  justify-content: flex-start;
+  width: 60%;
+
+  p {
+    margin-top: 0.8rem;
+  }
+`;
+
+const BookTitle = styled.h2`
+  font-size: 1.2rem;
+  max-height: 4.1rem;
+  overflow: hidden;
+`;
+
+const BookSubTitle = styled.h5`
+  margin: 0;
+  margin-top: 0.3rem;
+  max-height: 2rem;
+  overflow: hidden;
 `;

--- a/client/src/components/ShelfSelector.js
+++ b/client/src/components/ShelfSelector.js
@@ -1,0 +1,139 @@
+import { useState } from 'react';
+import styled from 'styled-components';
+
+import SaveAddButton from './SaveAddButton';
+
+export default function ShelfSelector({ shelves, book }) {
+  const initialSelection = {
+    bookshelf: '',
+    column: '',
+    compartment: '',
+  };
+  const [selection, setSelection] = useState(initialSelection);
+  const [shelfIndex, setShelfIndex] = useState(null);
+  const [columnIndex, setColumnIndex] = useState(null);
+
+  function handleBookShelfChange(event) {
+    const shelfIndex = shelves.findIndex(
+      (shelf) => shelf.id === event.target.value
+    );
+    shelfIndex >= 0 ? setShelfIndex(shelfIndex) : setShelfIndex(null);
+    setSelection({ ...selection, bookshelf: event.target.value, column: '' });
+  }
+
+  function handleColumnChange(event) {
+    const columnIndex = shelves[shelfIndex].columns.findIndex(
+      (column) => column.id === event.target.value
+    );
+    columnIndex >= 0 ? setColumnIndex(columnIndex) : setColumnIndex(null);
+    setSelection({ ...selection, column: event.target.value, compartment: '' });
+  }
+
+  function handleCompartmentChange(event) {
+    setSelection({ ...selection, compartment: event.target.value });
+  }
+
+  console.log(columnIndex);
+  console.log(shelves);
+  return (
+    <ShelfSelectorCard>
+      <ShelfPicker>
+        <div>
+          <label htmlFor="bookshelf">Bookshelf</label>
+          <select
+            name="bookshelf"
+            id="bookshelf"
+            onChange={handleBookShelfChange}
+            value={selection.bookshelf}
+          >
+            <option value="">-Bookshelves-</option>
+            {shelves.length > 0 &&
+              shelves.map((shelf, index) => (
+                <option key={index} value={shelf.id}>
+                  {shelf.name}
+                </option>
+              ))}
+          </select>
+        </div>
+        <div>
+          <label htmlFor="column">Column</label>
+          <select
+            name="column"
+            id="column"
+            onChange={handleColumnChange}
+            value={selection.column}
+          >
+            <option value="">-Column-</option>
+            {shelfIndex !== null &&
+              shelves[shelfIndex].columns.map((column, index) => (
+                <option key={index} value={column.id}>
+                  {column.column}
+                </option>
+              ))}
+          </select>
+        </div>
+        <div>
+          <label htmlFor="compartment">Compartment</label>
+          <select
+            name="compartment"
+            id="compartment"
+            value={selection.compartment}
+            onChange={handleCompartmentChange}
+          >
+            <option value="">-Compartment-</option>
+            {columnIndex !== null &&
+              shelves[shelfIndex].columns[columnIndex].compartments.map(
+                (compartment, index) => (
+                  <option key={index} value={compartment.compartment}>
+                    {compartment.compartment}
+                  </option>
+                )
+              )}
+          </select>
+        </div>
+      </ShelfPicker>
+      <SaveAddButton text={'Save'} />
+    </ShelfSelectorCard>
+  );
+}
+const ShelfSelectorCard = styled.article`
+  background-color: var(--background);
+  border-radius: var(--border-radius);
+  box-shadow: 0 0 80px 80px rgba(0, 0, 0, 0.2);
+  display: flex;
+  flex-direction: column;
+  flex-wrap: nowrap;
+  height: ${(props) => (props.isStatic ? '650px' : '20vh')};
+  margin: ${(props) => (props.isStatic ? '0 auto' : '50vh 50vw')};
+  opacity: 0.95;
+  padding: 1rem;
+  position: ${(props) => (props.isStatic ? 'relative' : 'fixed')};
+  transform: ${(props) => (props.isStatic ? '' : 'translate(-50%, -180%)')};
+  width: ${(props) => (props.isStatic ? '338px' : '80vw')};
+  z-index: 100;
+
+  input,
+  select {
+    border: 1px solid var(--primary);
+    border-radius: var(--border-radius);
+    background: var(--background);
+  }
+`;
+
+const ShelfPicker = styled.section`
+  display: flex;
+  justify-content: space-around;
+  margin: 1rem auto 2rem;
+  label {
+    display: block;
+    font-size: 0.8rem;
+    margin-bottom: 0.2rem;
+  }
+
+  input,
+  select {
+    box-shadow: var(--box-shadow-offset-x) var(--box-shadow-offset-y)
+      var(--box-shadow-blur) var(--box-shadow-color);
+    height: 2rem;
+  }
+`;

--- a/client/src/components/ShelfSelector.js
+++ b/client/src/components/ShelfSelector.js
@@ -1,4 +1,4 @@
-import ProptTypes from 'prop-types';
+import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { toast } from 'react-toastify';
 import { useState } from 'react';
@@ -8,6 +8,7 @@ import SaveAddButton from './SaveAddButton';
 import validateShelfSelection from '../lib/validateShelfSelection';
 
 export default function ShelfSelector({
+  isStatic,
   shelves,
   book,
   onSetIsSelector,
@@ -67,7 +68,7 @@ export default function ShelfSelector({
   }
 
   return (
-    <ShelfSelectorCard>
+    <ShelfSelectorCard isStatic={isStatic}>
       <CloseButton
         src={CloseIcon}
         alt="Close Icon"
@@ -166,7 +167,7 @@ const ShelfSelectorCard = styled.article`
   display: flex;
   flex-direction: column;
   flex-wrap: nowrap;
-  height: ${(props) => (props.isStatic ? '650px' : '50vh')};
+  height: ${(props) => (props.isStatic ? '350px' : '50vh')};
   justify-content: center;
   margin: ${(props) => (props.isStatic ? '0 auto' : '50vh 50vw')};
   opacity: 0.95;
@@ -196,6 +197,10 @@ const ShelfSelectorForm = styled.form`
   justify-content: space-around;
   margin: 1rem 0 1rem;
   width: 100%;
+
+  button {
+    align-self: center;
+  }
 
   label {
     display: block;

--- a/client/src/components/ShelfSelector.js
+++ b/client/src/components/ShelfSelector.js
@@ -15,9 +15,9 @@ export default function ShelfSelector({
   onSelectShelf,
 }) {
   const initialSelection = {
-    bookshelf: '',
-    column: '',
-    compartment: '',
+    bookshelfId: '',
+    columnId: '',
+    compartmentId: '',
   };
   const [selection, setSelection] = useState(initialSelection);
   const [shelfIndex, setShelfIndex] = useState(null);
@@ -30,9 +30,9 @@ export default function ShelfSelector({
     shelfIndex >= 0 ? setShelfIndex(shelfIndex) : setShelfIndex(null);
     setSelection({
       ...selection,
-      bookshelf: event.target.value,
-      column: '',
-      compartment: '',
+      bookshelfId: event.target.value,
+      columnId: '',
+      compartmentId: '',
     });
     toast.dismiss('validationError');
   }
@@ -42,12 +42,16 @@ export default function ShelfSelector({
       (column) => column.id === event.target.value
     );
     columnIndex >= 0 ? setColumnIndex(columnIndex) : setColumnIndex(null);
-    setSelection({ ...selection, column: event.target.value, compartment: '' });
+    setSelection({
+      ...selection,
+      columnId: event.target.value,
+      compartment: '',
+    });
     toast.dismiss('validationError');
   }
 
   function handleCompartmentChange(event) {
-    setSelection({ ...selection, compartment: event.target.value });
+    setSelection({ ...selection, compartmentId: event.target.value });
     toast.dismiss('validationError');
   }
 
@@ -100,45 +104,45 @@ export default function ShelfSelector({
       <ShelfSelectorForm onSubmit={handleSelectionSave}>
         <ShelfPicker>
           <div>
-            <label htmlFor="bookshelf">Bookshelf</label>
+            <label htmlFor="bookshelfId">Bookshelf</label>
             <select
-              name="bookshelf"
-              id="bookshelf"
+              name="bookshelfId"
+              id="bookshelfId"
               onChange={handleBookShelfChange}
-              value={selection.bookshelf}
+              value={selection.bookshelfId}
             >
               <option value="">-Select-</option>
               {shelves.length > 0 &&
                 shelves.map((shelf, index) => (
-                  <option key={index} value={shelf.id}>
+                  <option key={shelf.id} value={shelf.id}>
                     {shelf.name}
                   </option>
                 ))}
             </select>
           </div>
           <div>
-            <label htmlFor="column">Column</label>
+            <label htmlFor="columnId">Column</label>
             <select
-              name="column"
-              id="column"
+              name="columnId"
+              id="columnId"
               onChange={handleColumnChange}
-              value={selection.column}
+              value={selection.columnId}
             >
               <option value="">-Select-</option>
               {shelfIndex !== null &&
                 shelves[shelfIndex].columns.map((column, index) => (
-                  <option key={index} value={column.id}>
+                  <option key={column.id} value={column.id}>
                     {column.column}
                   </option>
                 ))}
             </select>
           </div>
           <div>
-            <label htmlFor="compartment">Compartment</label>
+            <label htmlFor="compartmentId">Compartment</label>
             <select
-              name="compartment"
-              id="compartment"
-              value={selection.compartment}
+              name="compartmentId"
+              id="compartmentId"
+              value={selection.compartmentId}
               onChange={handleCompartmentChange}
             >
               <option value="">-Select-</option>
@@ -146,7 +150,7 @@ export default function ShelfSelector({
                 columnIndex !== null &&
                 shelves[shelfIndex].columns[columnIndex].compartments.map(
                   (compartment, index) => (
-                    <option key={index} value={compartment.id}>
+                    <option key={compartment.id} value={compartment.id}>
                       {compartment.compartment}
                     </option>
                   )
@@ -154,7 +158,7 @@ export default function ShelfSelector({
             </select>
           </div>
         </ShelfPicker>
-        <SaveAddButton text={'Save'} />
+        <SaveAddButton text="Save" />
       </ShelfSelectorForm>
     </ShelfSelectorCard>
   );

--- a/client/src/components/ShelfSelector.md
+++ b/client/src/components/ShelfSelector.md
@@ -1,0 +1,69 @@
+```jsx
+const book = {
+  rating: 1,
+  volumeInfo: {
+    title: 'Die Furcht des Weisen / Band 1',
+    subtitle: 'Die Königsmörder-Chronik. Zweiter Tag',
+    publishedDate: '2011-10-01',
+    authors: ['Patrick Rothfuss'],
+    imageLinks: {
+      thumbnail:
+        'http://books.google.com/books/content?id=sjDmcnAKAysC&printsec=frontcover&img=1&zoom=1&edge=curl&source=gbs_api',
+    },
+    industryIdentifiers: [{ identifier: '9783608102260' }],
+  },
+};
+const shelves = [
+  {
+    id: '3b2ae99d-0b5b-4e8b-9221-eab5f1634b9d',
+    name: 'Shelf 1',
+    columns: [
+      {
+        id: 'fb413524-8d1e-4cc4-a19e-5855e9696cf3',
+        column: 1,
+        compartments: [
+          {
+            compartment: 1,
+            id: '1dc4d8be-db31-4d44-8561-ef39cfd349b5',
+          },
+          {
+            compartment: 2,
+            id: '17368c59-cf4f-4079-86f0-3425b1c60eb6',
+          },
+        ],
+        width: 1,
+        height: 2,
+      },
+      {
+        id: '71fe7a93-c17c-4876-8298-b1f17dc73b36',
+        column: 2,
+        compartments: [
+          {
+            compartment: 1,
+            id: '04bb1919-018e-45d6-8824-d4187503fbef',
+          },
+          {
+            compartment: 2,
+            id: '20ad9086-de95-44ac-b061-57a66b9b6c3f',
+          },
+          {
+            compartment: 3,
+            id: '9e37c70c-d1ff-4ac7-87c5-ed0fc7abc31e',
+          },
+        ],
+        width: 1,
+        height: 1,
+      },
+    ],
+    color: 'white',
+  },
+];
+
+<ShelfSelector
+  isStatic
+  book={book}
+  shelves={shelves}
+  onSetIsSelector={() => true}
+  onSelectShelf={() => true}
+/>;
+```

--- a/client/src/lib/validateShelfSelection.js
+++ b/client/src/lib/validateShelfSelection.js
@@ -1,0 +1,11 @@
+const validateShelf = (bookshelf) => bookshelf !== '';
+const validateColumn = (column) => column !== '';
+const validateCompartment = (compartment) => compartment !== '';
+
+export default function validateShelfSelection(selection) {
+  return (
+    validateShelf(selection.bookshelf) &&
+    validateColumn(selection.column) &&
+    validateCompartment(selection.compartment)
+  );
+}

--- a/client/src/lib/validateShelfSelection.js
+++ b/client/src/lib/validateShelfSelection.js
@@ -1,11 +1,11 @@
-const validateShelf = (bookshelf) => bookshelf !== '';
-const validateColumn = (column) => column !== '';
-const validateCompartment = (compartment) => compartment !== '';
+const validateShelf = (bookshelfId) => bookshelfId !== '';
+const validateColumn = (columnId) => columnId !== '';
+const validateCompartment = (compartmentId) => compartmentId !== '';
 
 export default function validateShelfSelection(selection) {
   return (
-    validateShelf(selection.bookshelf) &&
-    validateColumn(selection.column) &&
-    validateCompartment(selection.compartment)
+    validateShelf(selection.bookshelfId) &&
+    validateColumn(selection.columnId) &&
+    validateCompartment(selection.compartmentId)
   );
 }

--- a/client/src/pages/Home.js
+++ b/client/src/pages/Home.js
@@ -23,4 +23,6 @@ export default function Home({
 Home.propTypes = {
   onToggleToAndFromLibrary: PropTypes.func,
   isInLibrary: PropTypes.func,
+  shelves: PropTypes.array,
+  onSelectShelf: PropTypes.func,
 };

--- a/client/src/pages/Home.js
+++ b/client/src/pages/Home.js
@@ -5,6 +5,7 @@ export default function Home({
   onToggleToAndFromLibrary,
   isInLibrary,
   shelves,
+  onSelectShelf,
 }) {
   return (
     <main>
@@ -13,6 +14,7 @@ export default function Home({
         onToggleToAndFromLibrary={onToggleToAndFromLibrary}
         isInLibrary={isInLibrary}
         shelves={shelves}
+        onSelectShelf={onSelectShelf}
       />
     </main>
   );

--- a/client/src/pages/Home.js
+++ b/client/src/pages/Home.js
@@ -1,13 +1,18 @@
 import GlobalSearch from '../components/GlobalSearch';
 import PropTypes from 'prop-types';
 
-export default function Home({ onToggleToAndFromLibrary, isInLibrary }) {
+export default function Home({
+  onToggleToAndFromLibrary,
+  isInLibrary,
+  shelves,
+}) {
   return (
     <main>
       <h2>Home</h2>
       <GlobalSearch
         onToggleToAndFromLibrary={onToggleToAndFromLibrary}
         isInLibrary={isInLibrary}
+        shelves={shelves}
       />
     </main>
   );


### PR DESCRIPTION
I have implemented a feature that allows adding a book to a shelf. For now, when searching a book (on /home) and clicking on "add", a "modal" will open with a shelf selector. The dropdowns will be populated based on the saved shelves (if there are none, they would need to be created first on /myshelves). Selecting a shelf, column and compartment and saving would add a reference as follows:

a) on the book, the IDs of the bookshelf, column and compartment will be added to a property "shelfLocation".
b) on the shelf, the book's ID would be added to the respective compartment with the property "storedBooks"

For now, the location is only implemented on the "/mybooks" page when you open up the detailed view by clicking on a book that's in your library (and has been added to a shelf successfully).

Cypress tests will be added at a later stage when more is done with the location. StyleGuidist has been added.

It can be tested here https://bookshelves-feat-addboo-1e1g3a.herokuapp.com/ (please use mobile view)


PS: I am aware of the "Mixed content" error and am planning to fix it in a later commit. :)
