### PR TITLE
Render Book Covers / Book Count in Shelves

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -131,32 +131,33 @@ function App() {
 
   function getShelfBooks(shelf) {
     const shelfBooks = [];
-    shelf &&
-      shelf.columns.map((column, columnIndex) => {
+    if (shelf) {
+      shelf.columns.forEach((column, columnIndex) => {
         shelfBooks.push([]);
-        column.compartments.map((compartment) =>
+        column.compartments.forEach((compartment) =>
           compartment.storedBooks
-            ? shelfBooks[columnIndex].push(compartment.storedBooks)
+            ? shelfBooks[columnIndex].push([...compartment.storedBooks])
             : shelfBooks[columnIndex].push([])
         );
-        return shelfBooks;
       });
-    shelfBooks.map((columnBooks, shelfBooksColumnIndex) =>
-      columnBooks.map((compartmentBooks, compartmentIndex) => {
-        compartmentBooks.map((bookId, bookIndex) =>
-          library.map((book) => {
-            if (book.id === bookId) {
-              shelfBooks[shelfBooksColumnIndex][compartmentIndex][bookIndex] =
-                book.volumeInfo?.imageLinks?.thumbnail;
-              return shelfBooks;
-            }
-            return shelfBooks;
-          })
-        );
-        return shelfBooks;
-      })
-    );
-    return shelfBooks;
+      shelfBooks.map((columnBooks, shelfBooksColumnIndex) =>
+        columnBooks.map((compartmentBooks, compartmentIndex) => {
+          compartmentBooks.map((bookId, bookIndex) =>
+            library.map((book) => {
+              if (book.id === bookId) {
+                shelfBooks[shelfBooksColumnIndex][compartmentIndex][bookIndex] =
+                  book.volumeInfo?.imageLinks?.thumbnail;
+                return shelfBooks;
+              }
+              return compartmentBooks;
+            })
+          );
+          return columnBooks;
+        })
+      );
+
+      return shelfBooks;
+    }
   }
 
   function provideDetailedShelfHelper(shelf, column, compartment) {

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -131,15 +131,16 @@ function App() {
 
   function getShelfBooks(shelf) {
     const shelfBooks = [];
-    shelf.columns.map((column, columnIndex) => {
-      shelfBooks.push([]);
-      column.compartments.map((compartment) =>
-        compartment.storedBooks
-          ? shelfBooks[columnIndex].push(compartment.storedBooks)
-          : shelfBooks[columnIndex].push([])
-      );
-      return shelfBooks;
-    });
+    shelf &&
+      shelf.columns.map((column, columnIndex) => {
+        shelfBooks.push([]);
+        column.compartments.map((compartment) =>
+          compartment.storedBooks
+            ? shelfBooks[columnIndex].push(compartment.storedBooks)
+            : shelfBooks[columnIndex].push([])
+        );
+        return shelfBooks;
+      });
     shelfBooks.map((columnBooks, shelfBooksColumnIndex) =>
       columnBooks.map((compartmentBooks, compartmentIndex) => {
         compartmentBooks.map((bookId, bookIndex) =>

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -21,7 +21,7 @@ function App() {
     compartment: { id: 123 },
   });
   const [detailedCompartmentBooks, setDetailedCompartmentBooks] = useState([]);
-
+  console.log('app', shelves);
   function toggleToAndFromLibrary(focusedBook) {
     isInLibrary(focusedBook)
       ? removeFromLibrary(focusedBook)
@@ -131,26 +131,29 @@ function App() {
 
   function getShelfBooks(shelf) {
     const shelfBooks = [];
-    shelf &&
-      shelf.columns.map((column, columnIndex) => {
-        shelfBooks.push([]);
-        column.compartments.map((compartment) =>
-          compartment.storedBooks
-            ? shelfBooks[columnIndex].push(compartment.storedBooks)
-            : shelfBooks[columnIndex].push([])
+    shelf.columns.map((column, columnIndex) => {
+      shelfBooks.push([]);
+      column.compartments.map((compartment) =>
+        compartment.storedBooks
+          ? shelfBooks[columnIndex].push(compartment.storedBooks)
+          : shelfBooks[columnIndex].push([])
+      );
+      return shelfBooks;
+    });
+    shelfBooks.map((columnBooks, shelfBooksColumnIndex) =>
+      columnBooks.map((compartmentBooks, compartmentIndex) => {
+        compartmentBooks.map((bookId, bookIndex) =>
+          library.map((book) => {
+            if (book.id === bookId) {
+              shelfBooks[shelfBooksColumnIndex][compartmentIndex][bookIndex] =
+                book.volumeInfo?.imageLinks?.thumbnail;
+              return shelfBooks;
+            }
+            return shelfBooks;
+          })
         );
         return shelfBooks;
-      });
-    shelfBooks.map((compartmentBooks, columnIndex) =>
-      compartmentBooks.map((bookId, compartmentIndex) =>
-        library.map((book) => {
-          if (book.id === bookId) {
-            shelfBooks[columnIndex][compartmentIndex] =
-              book.volumeInfo?.imageLinks?.thumbnail;
-          }
-          return shelfBooks;
-        })
-      )
+      })
     );
     return shelfBooks;
   }

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -155,7 +155,6 @@ function App() {
           return columnBooks;
         })
       );
-
       return shelfBooks;
     }
   }

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -21,13 +21,13 @@ function App() {
     compartment: { id: 123 },
   });
   const [detailedCompartmentBooks, setDetailedCompartmentBooks] = useState([]);
-  console.log('app', shelves);
+
   function toggleToAndFromLibrary(focusedBook) {
     isInLibrary(focusedBook)
       ? removeFromLibrary(focusedBook)
       : addToLibrary(focusedBook);
   }
-  console.log(library);
+
   function addToLibrary(focusedBook) {
     setLibrary([...library, focusedBook]);
   }

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -129,6 +129,32 @@ function App() {
     }
   }
 
+  function getShelfBooks(shelf) {
+    const shelfBooks = [];
+    shelf &&
+      shelf.columns.map((column, columnIndex) => {
+        shelfBooks.push([]);
+        column.compartments.map((compartment) =>
+          compartment.storedBooks
+            ? shelfBooks[columnIndex].push(compartment.storedBooks)
+            : shelfBooks[columnIndex].push([])
+        );
+        return shelfBooks;
+      });
+    shelfBooks.map((compartmentBooks, columnIndex) =>
+      compartmentBooks.map((bookId, compartmentIndex) =>
+        library.map((book) => {
+          if (book.id === bookId) {
+            shelfBooks[columnIndex][compartmentIndex] =
+              book.volumeInfo?.imageLinks?.thumbnail;
+          }
+          return shelfBooks;
+        })
+      )
+    );
+    return shelfBooks;
+  }
+
   function provideDetailedShelfHelper(shelf, column, compartment) {
     const detailedShelfCompartment = {
       shelf: shelf,
@@ -168,6 +194,8 @@ function App() {
             shelves={shelves}
             onGetCompartmentBooks={getCompartmentBooks}
             onProvideDetailedShelf={provideDetailedShelfHelper}
+            detailedCompartmentBooks={detailedCompartmentBooks}
+            onGetShelfBooks={getShelfBooks}
           />
         </Route>
         <Route path="/myshelves/createshelf">

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -27,7 +27,7 @@ function App() {
       ? removeFromLibrary(focusedBook)
       : addToLibrary(focusedBook);
   }
-
+  console.log(library);
   function addToLibrary(focusedBook) {
     setLibrary([...library, focusedBook]);
   }
@@ -129,7 +129,7 @@ function App() {
     }
   }
 
-  function getShelfBooks(shelf) {
+  function getShelfBookImages(shelf) {
     const shelfBooks = [];
     if (shelf) {
       shelf.columns.forEach((column, columnIndex) => {
@@ -199,7 +199,7 @@ function App() {
             onGetCompartmentBooks={getCompartmentBooks}
             onProvideDetailedShelf={provideDetailedShelfHelper}
             detailedCompartmentBooks={detailedCompartmentBooks}
-            onGetShelfBooks={getShelfBooks}
+            onGetShelfBooks={getShelfBookImages}
           />
         </Route>
         <Route path="/myshelves/createshelf">

--- a/client/src/components/Shelf.js
+++ b/client/src/components/Shelf.js
@@ -1,4 +1,5 @@
 import PropTypes from 'prop-types';
+import { useEffect, useState } from 'react';
 import { Link, useRouteMatch } from 'react-router-dom';
 import styled from 'styled-components/macro';
 
@@ -11,6 +12,7 @@ export default function Shelf({
   isSaved,
   bookImages,
 }) {
+  const [compartmentHeights, setCompartmentHeights] = useState([]);
   let { url } = useRouteMatch();
 
   function shelfWidth(index) {
@@ -20,6 +22,20 @@ export default function Shelf({
         : (100 / shelf.columns.length) * shelf.columns[index].width;
     return columnWidth;
   }
+  console.log('heights', compartmentHeights);
+  useEffect(() => {
+    setCompartmentHeights([]);
+    const columns = document?.querySelectorAll('#column');
+    const height = [];
+
+    columns.forEach((column, columnIndex) => {
+      height.push([]);
+      column.childNodes.forEach((compartment) =>
+        height[columnIndex].push(compartment.clientHeight)
+      );
+    });
+    setCompartmentHeights(height);
+  }, [shelf]);
 
   function checkForHeight(value) {
     return shelf.columns.some((column) => column.height === value);
@@ -46,6 +62,7 @@ export default function Shelf({
         child={columnIndex}
         getColor={getShelfBorders(shelf.color)}
         data-test-id="column"
+        id="column"
       >
         {column.compartments &&
           column.compartments.length > 0 &&
@@ -55,29 +72,39 @@ export default function Shelf({
                 key={'compartment' + compartmentIndex}
                 getColor={getShelfBorders(shelf.color)}
                 data-test-id="compartment"
+                id="compartment"
               >
                 {isSaved && (
-                  <Link
-                    key={compartmentIndex}
-                    to={`${url}/${compartment.id}`}
-                    onClick={() =>
-                      compartmentClickHandler(shelf, column, compartment)
-                    }
-                    data-test-id="compartment-link"
-                  >
-                    {bookImages.length > 0 &&
-                      bookImages[columnIndex][compartmentIndex]?.map(
-                        (bookImageURL, bookImageIndex) => {
-                          return (
-                            <img
-                              key={bookImageIndex}
-                              src={bookImageURL}
-                              alt="book cover"
-                            />
-                          );
-                        }
-                      )}
-                  </Link>
+                  <div>
+                    <Link
+                      key={compartmentIndex}
+                      to={`${url}/${compartment.id}`}
+                      onClick={() =>
+                        compartmentClickHandler(shelf, column, compartment)
+                      }
+                      data-test-id="compartment-link"
+                    >
+                      {compartmentHeights.length > 1 &&
+                        compartmentHeights[columnIndex][compartmentIndex] >
+                          95 &&
+                        bookImages &&
+                        bookImages.length > 0 &&
+                        bookImages[columnIndex][compartmentIndex]?.map(
+                          (bookImageURL, bookImageIndex) => {
+                            return (
+                              <img
+                                key={bookImageIndex}
+                                src={bookImageURL}
+                                alt="book cover"
+                              />
+                            );
+                          }
+                        )}
+                      {compartmentHeights.length > 1 &&
+                        compartmentHeights[columnIndex][compartmentIndex] <
+                          95 && <p>{compartment?.storedBooks?.length}</p>}
+                    </Link>
+                  </div>
                 )}
               </Compartment>
             );
@@ -119,9 +146,19 @@ const Compartment = styled.div`
     border-bottom: 3px solid var(--background);
     border-top: none;
   }
+  div {
+    margin: 0 auto;
+    width: 80%;
+    height: 95%;
+    display: flex;
+    justify-content: center;
+    align-items: center;
 
-  img {
-    width: 30%;
+    img {
+      width: 32%;
+      height: auto;
+      object-fit: cover;
+    }
   }
 `;
 

--- a/client/src/components/Shelf.js
+++ b/client/src/components/Shelf.js
@@ -9,6 +9,7 @@ export default function Shelf({
   onGetCompartmentBooks,
   onProvideDetailedShelf,
   isSaved,
+  bookImages,
 }) {
   let { url } = useRouteMatch();
 
@@ -32,45 +33,50 @@ export default function Shelf({
 
   function compartmentClickHandler(shelf, column, compartment) {
     onGetCompartmentBooks(compartment.storedBooks);
+    console.log('shelf', compartment);
     onProvideDetailedShelf(shelf, column, compartment);
   }
 
-  return shelf.columns.map((column, index) => {
+  return shelf.columns.map((column, columnIndex) => {
     return (
       <Column
-        key={'column' + index}
-        shelfWidth={shelfWidth(index)}
-        shelfHeight={shelfHeight(index)}
-        child={index}
+        key={'column' + columnIndex}
+        shelfWidth={shelfWidth(columnIndex)}
+        shelfHeight={shelfHeight(columnIndex)}
+        child={columnIndex}
         getColor={getShelfBorders(shelf.color)}
         data-test-id="column"
       >
         {column.compartments &&
           column.compartments.length > 0 &&
-          column.compartments.map((compartment, index) => {
+          column.compartments.map((compartment, compartmentIndex) => {
             return (
               <Compartment
-                key={'compartment' + index}
+                key={'compartment' + compartmentIndex}
                 getColor={getShelfBorders(shelf.color)}
                 data-test-id="compartment"
               >
                 {isSaved && (
                   <Link
-                    key={index}
+                    key={compartmentIndex}
                     to={`${url}/${compartment.id}`}
                     onClick={() =>
                       compartmentClickHandler(shelf, column, compartment)
                     }
                     data-test-id="compartment-link"
                   >
-                    {/*  {shelfBooks.map((book) => {
-                      return (
-                        <img
-                          src={book.volumeInfo?.imageLinks?.thumbnail}
-                          alt="book cover"
-                        />
-                      );
-                    })} */}
+                    {bookImages.length > 0 &&
+                      bookImages[columnIndex][compartmentIndex]?.map(
+                        (bookImageURL, bookImageIndex) => {
+                          return (
+                            <img
+                              key={bookImageIndex}
+                              src={bookImageURL}
+                              alt="book cover"
+                            />
+                          );
+                        }
+                      )}
                   </Link>
                 )}
               </Compartment>
@@ -96,6 +102,9 @@ const Column = styled.div`
 `;
 
 const Compartment = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
   border: ${(props) => props.getColor};
   border-left: none;
   border-right: none;
@@ -109,6 +118,10 @@ const Compartment = styled.div`
   :first-child {
     border-bottom: 3px solid var(--background);
     border-top: none;
+  }
+
+  img {
+    width: 30%;
   }
 `;
 

--- a/client/src/components/Shelf.js
+++ b/client/src/components/Shelf.js
@@ -18,7 +18,6 @@ export default function Shelf({
   useEffect(() => {
     determineCompartmentRenderDimensions();
   }, [shelf]);
-  console.log(compartmentDimensions);
 
   function determineCompartmentRenderDimensions() {
     setCompartmentDimensions([]);
@@ -58,7 +57,6 @@ export default function Shelf({
 
   function compartmentClickHandler(shelf, column, compartment) {
     onGetCompartmentBooks(compartment.storedBooks);
-    console.log('shelf', compartment);
     onProvideDetailedShelf(shelf, column, compartment);
   }
 
@@ -81,7 +79,6 @@ export default function Shelf({
                 key={'compartment' + compartmentIndex}
                 getColor={getShelfBorders(shelf.color)}
                 data-test-id="compartment"
-                id="compartment"
               >
                 {isSaved && (
                   <BookImageWrapper>
@@ -210,7 +207,6 @@ const BookImageWrapper = styled.div`
 const LinkStyled = styled(Link)`
   color: black;
   display: flex;
-  height: 100;
   justify-content: center;
   margin: 0 auto;
   position: relative;

--- a/client/src/components/Shelf.js
+++ b/client/src/components/Shelf.js
@@ -63,7 +63,14 @@ export default function Shelf({
                     }
                     data-test-id="compartment-link"
                   >
-                    <p>CLICK ME</p>
+                    {/*  {shelfBooks.map((book) => {
+                      return (
+                        <img
+                          src={book.volumeInfo?.imageLinks?.thumbnail}
+                          alt="book cover"
+                        />
+                      );
+                    })} */}
                   </Link>
                 )}
               </Compartment>

--- a/client/src/pages/MyShelves.js
+++ b/client/src/pages/MyShelves.js
@@ -1,6 +1,6 @@
 import { Link } from 'react-router-dom';
 import PropTypes from 'prop-types';
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 import { useEffect, useState } from 'react';
 
 import SaveAddButton from '../components/SaveAddButton';
@@ -68,9 +68,9 @@ export default function MyShelves({
           </ShelfWrapper>
         </>
       )}
-      <Link to="/myshelves/createshelf">
+      <LinkStyled to="/myshelves/createshelf">
         <SaveAddButton text={'Add New Shelf'} />
-      </Link>
+      </LinkStyled>
     </ShelfPage>
   );
 }
@@ -79,13 +79,6 @@ const ShelfPage = styled.main`
   align-items: center;
   display: flex;
   flex-direction: column;
-
-  a {
-    display: flex;
-    justify-content: center;
-    text-decoration: none;
-    width: 100%;
-  }
 `;
 
 const NoShelvesMessage = styled.p`
@@ -117,6 +110,12 @@ const ShelfWrapper = styled.article`
   justify-content: center;
   margin: 0 auto 1rem;
   width: 95%;
+`;
+const LinkStyled = styled(Link)`
+  display: flex;
+  justify-content: center;
+  text-decoration: none;
+  width: 100%;
 `;
 
 MyShelves.propTypes = {

--- a/client/src/pages/MyShelves.js
+++ b/client/src/pages/MyShelves.js
@@ -1,7 +1,7 @@
 import { Link } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import SaveAddButton from '../components/SaveAddButton';
 import Shelf from '../components/Shelf';
@@ -12,8 +12,16 @@ export default function MyShelves({
   shelves,
   onGetCompartmentBooks,
   onProvideDetailedShelf,
+  onGetShelfBooks,
 }) {
   const [shelfIndex, setShelfIndex] = useState(0);
+  const [bookImages, setBookImages] = useState([]);
+
+  useEffect(() => {
+    setBookImages(onGetShelfBooks(shelves[shelfIndex]));
+  }, [shelfIndex]);
+
+  console.log(bookImages);
 
   function goForward() {
     if (isShelfAfter()) setShelfIndex(shelfIndex + 1);

--- a/client/src/pages/MyShelves.js
+++ b/client/src/pages/MyShelves.js
@@ -21,8 +21,6 @@ export default function MyShelves({
     setBookImages(onGetShelfBooks(shelves[shelfIndex]));
   }, [shelfIndex]);
 
-  console.log(bookImages);
-
   function goForward() {
     if (isShelfAfter()) setShelfIndex(shelfIndex + 1);
   }
@@ -65,6 +63,7 @@ export default function MyShelves({
               onGetCompartmentBooks={onGetCompartmentBooks}
               onProvideDetailedShelf={onProvideDetailedShelf}
               isSaved={true}
+              bookImages={bookImages}
             />
           </ShelfWrapper>
         </>


### PR DESCRIPTION
Implemented a feature where books added to shelves and compartments are rendered within the compartments on the /myshelves page. Depending on the size of the compartment (when being rendered in the DOM), a dynamically calculated number of covers will be displayed with a dynamically calculated size. If there are more books in the compartment than can be displayed in the shelf-view, then there is a little circle displaying the additional count of books in the compartment.

If the compartment is so small that it makes no sense to display a book cover image, the current solution is to just display the number of books in the compartment.

Test here: https://bookshelves-feat-render-bbvgyf.herokuapp.com/ (please use mobile view).

Two notes: 
1. Currently, there is no local storage / database connection, so you would need to create a shelf on /myshelves (middle icon), and add books to it by searching for them on /home. 
2. I am aware of the mixed content error that occurs when searching (and the image fetch occurs).

THANKS



